### PR TITLE
Fix(Templates): Replace displayable fullname

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -80,7 +80,7 @@ class UserSerializer(serializers.ModelSerializer):
     full_name = serializers.SerializerMethodField()
 
     def get_full_name(self, obj):
-        return obj.get_full_name()
+        return obj.get_full_name() or obj.username
 
     class Meta:
         model = User
@@ -285,7 +285,7 @@ class EventSerializer(serializers.ModelSerializer):
 
     created_on = serializers.DateTimeField(format="%d/%m/%Y %H:%M", read_only=True)
 
-    user = UserSerializer(read_only=True)
+    display_user = serializers.ReadOnlyField()
 
     related_comment = serializers.SerializerMethodField()
 
@@ -344,7 +344,7 @@ class EventSerializer(serializers.ModelSerializer):
             'feature_id',
             'comment_id',
             'attachment_id',
-            'user',
+            'display_user',
             'related_comment',
             'related_feature',
             'project_url',

--- a/geocontrib/models.py
+++ b/geocontrib/models.py
@@ -692,6 +692,13 @@ class Event(models.Model):
         super().save(*args, **kwargs)
 
     @property
+    def display_user(self):
+        res = "Utilisateur supprimé"
+        if self.user:
+            res = self.user.get_full_name() or self.user.username
+        return res
+
+    @property
     def contextualize_action(self):
         evt = 'Aucun evenement'
         obj = 'defini'

--- a/geocontrib/templates/geocontrib/email/notif_suscriber_grouped_events.html
+++ b/geocontrib/templates/geocontrib/email/notif_suscriber_grouped_events.html
@@ -16,7 +16,7 @@
               {% if event.event_type == 'delete' %}
                 {% if event.object_type == 'feature' %}
                 {{ event.created_on }} - "{{ event.data.feature_title }}"
-                  Signalement supprimé par {{ event.user.full_name }}
+                  Signalement supprimé par {{ event.display_user }}
                 {% endif %}
               {% else %}
 
@@ -29,10 +29,10 @@
                 {% if event.event_type == 'create' %}
 
                   {% if event.object_type == 'feature' %}
-                    Signalement créé par {{ event.user.full_name }}
+                    Signalement créé par {{ event.display_user }}
 
                   {% elif event.object_type == 'comment' %}
-                    - Commentaire créé par {{ event.user.full_name }}
+                    - Commentaire créé par {{ event.display_user }}
                     <strong>{{ event.related_comment.comment }}</strong>
                     {% if event.related_comment.attachments %}
                       {% for att in event.related_comment.attachments %}
@@ -41,16 +41,16 @@
                     {% endif %}
 
                   {% elif event.object_type == 'attachment' %}
-                    {{ event.created_on }} - Pièce-jointe ajoutée par {{ event.user.full_name }}
+                    {{ event.created_on }} - Pièce-jointe ajoutée par {{ event.display_user }}
                   {% endif %}
 
                 {% elif event.event_type == 'update' %}
 
                   {% if event.object_type == 'feature' %}
-                    Signalement mis à jour par {{ event.user.full_name }}
+                    Signalement mis à jour par {{ event.display_user }}
 
                   {% elif event.object_type == 'attachment' %}
-                    Pièce-jointe mise à jour par {{ event.user.full_name }}
+                    Pièce-jointe mise à jour par {{ event.display_user }}
                   {% endif %}
 
                 {% endif %}

--- a/geocontrib/templates/geocontrib/feature/feature_detail.html
+++ b/geocontrib/templates/geocontrib/feature/feature_detail.html
@@ -168,7 +168,7 @@
                   {{ event.created_on }}
                 </div>
                 Création du signalement
-                {% if user.is_authenticated %} par {{ event.user.full_name }}{% endif %}
+                {% if user.is_authenticated %} par {{ event.display_user }}{% endif %}
               </div>
             </div>
           </div>
@@ -180,7 +180,7 @@
                   {{ event.created_on }}
                 </div>
                 Commentaire
-                {% if user.is_authenticated %} par {{ event.user.full_name }}{% endif %}
+                {% if user.is_authenticated %} par {{ event.display_user }}{% endif %}
               </div>
               <div class="extra text">
                 {{ event.related_comment.comment }}
@@ -201,7 +201,7 @@
                 {{ event.created_on }}
               </div>
               Signalement mis à jour
-              {% if user.is_authenticated %} par {{ event.user.full_name }}{% endif %}
+              {% if user.is_authenticated %} par {{ event.display_user }}{% endif %}
             </div>
           </div>
         </div>

--- a/geocontrib/templates/geocontrib/my_account.html
+++ b/geocontrib/templates/geocontrib/my_account.html
@@ -139,7 +139,7 @@
                       {% endif %}
                     </div>
                     <div class="description">
-                      <i>[ {{ item.created_on }}{% if user.is_authenticated %}, par {{ item.user.full_name }}{% endif %} ]</i>
+                      <i>[ {{ item.created_on }}{% if user.is_authenticated %}, par {{ item.display_user }}{% endif %} ]</i>
                     </div>
                   </div>
                 </div>
@@ -166,7 +166,7 @@
                       {% endif %}
                     </div>
                     <div class="description">
-                      <i>[ {{ item.created_on }}{% if user.is_authenticated %}, par {{ item.user.full_name }}{% endif %} ]</i>
+                      <i>[ {{ item.created_on }}{% if user.is_authenticated %}, par {{ item.display_user }}{% endif %} ]</i>
                     </div>
                   </div>
                 </div>
@@ -189,7 +189,7 @@
                       <a href="{{ item.related_feature.feature_url }}">"{{ item.related_comment.comment }}"</a>
                     </div>
                     <div class="description">
-                      <i>[ {{ item.created_on }}{% if user.is_authenticated %}, par {{ item.user.full_name }}{% endif %} ]</i>
+                      <i>[ {{ item.created_on }}{% if user.is_authenticated %}, par {{ item.display_user }}{% endif %} ]</i>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
- Feature, Comment, and Event instances may be linked to a deleted User 
instance. Fullnames displayed in templates are defined as models 
properties.