### PR TITLE
color kept as property in serialized feature

### DIFF
--- a/geocontrib/models/feature.py
+++ b/geocontrib/models/feature.py
@@ -8,6 +8,7 @@ from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ValidationError
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.functional import cached_property
 
 from geocontrib.choices import TYPE_CHOICES
 from geocontrib.managers import AvailableFeaturesManager
@@ -113,7 +114,7 @@ class Feature(models.Model):
             res = self.creator.get_full_name() or self.creator.username
         return res
 
-    @property
+    @cached_property
     def color(self):
         color = self.feature_type.color
         if self.feature_data and self.feature_type.colors_style:


### PR DESCRIPTION
j'ai testé avec/sans la couleur calculée coté back, le temps de réponse est le meme (dû peut-etre au prefetch)
j'ai ajouter un cached_property pour avoir bonne conscience, mais ca change pas grand chose avec un simple ppt python.