### PR TITLE
update 01_install docker-entrypoint.d script

### DIFF
--- a/docker/geocontrib/docker-entrypoint.d/01_install
+++ b/docker/geocontrib/docker-entrypoint.d/01_install
@@ -41,7 +41,7 @@ else
     i=1
     while true
     do
-        if  $(nc -z ${DB_HOST} 5432) ; then
+        if  $(nc -z ${DB_HOST} ${DB_PORT:-5432}) ; then
             echo "[${DB_HOST}] The database server is ready."
             break
         fi


### PR DESCRIPTION
`DB_PORT` can be passed as env variable, use it instead of assuming the db server will use 5432 (or use 5432 by default anyway)